### PR TITLE
Reuse a temp dir per device

### DIFF
--- a/crates/applesauce/src/lib.rs
+++ b/crates/applesauce/src/lib.rs
@@ -19,6 +19,7 @@ mod rfork_storage;
 mod scan;
 mod seq_queue;
 mod threads;
+mod tmpdir_paths;
 mod xattr;
 
 use libc::c_char;

--- a/crates/applesauce/src/tmpdir_paths.rs
+++ b/crates/applesauce/src/tmpdir_paths.rs
@@ -1,0 +1,71 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fs::Metadata;
+use std::io;
+use std::os::macos::fs::MetadataExt;
+use std::path::Path;
+use tempfile::{NamedTempFile, TempDir};
+
+const TEMPDIR_PREFIX: &str = "applesauce_tmp";
+const TEMPFILE_PREFIX: &str = "applesauce_tmp";
+
+#[derive(Debug)]
+pub struct TmpdirPaths {
+    /// Map from device to temp dir
+    dirs: HashMap<u64, TempDir>,
+}
+
+impl TmpdirPaths {
+    pub fn new() -> Self {
+        let mut dirs = HashMap::new();
+        let system = TempDir::with_prefix(TEMPDIR_PREFIX);
+        match system {
+            Ok(system) => match system.path().metadata() {
+                Ok(system_metadata) => {
+                    dirs.insert(system_metadata.st_dev(), system);
+                }
+                Err(e) => {
+                    tracing::warn!("failed to get metadata for system temp dir: {e}");
+                }
+            },
+            Err(e) => {
+                tracing::warn!("failed to create temp dir in system temp dir: {e}");
+            }
+        }
+
+        Self { dirs }
+    }
+
+    pub fn paths(&self) -> impl Iterator<Item = &Path> + '_ {
+        self.dirs.values().map(|dir| dir.path())
+    }
+
+    pub fn add_dst(&mut self, dst: &Path, metadata: &Metadata) -> io::Result<()> {
+        let device = metadata.st_dev();
+        match self.dirs.entry(device) {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                let dir = TempDir::with_prefix_in(TEMPDIR_PREFIX, dst)?;
+                entry.insert(dir);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn tempfile_for(&self, path: &Path, metadata: &Metadata) -> io::Result<NamedTempFile> {
+        let device = metadata.st_dev();
+        match self.dirs.get(&device) {
+            Some(dir) => tempfile::Builder::new()
+                .prefix(TEMPFILE_PREFIX)
+                .tempfile_in(dir.path()),
+            None => {
+                let parent = path
+                    .parent()
+                    .ok_or_else(|| io::Error::other("expected path to have a parent"))?;
+                tempfile::Builder::new()
+                    .prefix(TEMPFILE_PREFIX)
+                    .tempfile_in(parent)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Try to use the system tempdir first, then make a tempdir per device the root directories reside on.

This has several benefits:
- Most of the time, we'll use the common system tempdir entirely
- We will now exclude the tempdir we use for each root: it used to be possible for the temp files to be picked up by the reader thread: this is now only possible if we cross into a different device than all root dirs.