### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "applesauce",
  "cfg-if",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.0...applesauce-cli-v0.5.1) - 2024-04-15
+
+### Added
+- Reset directory modified times as well
+
+### Other
+- update Cargo.lock dependencies
+- Update readme with better install options
+- Appease clippy

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.5.0", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.5.1", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.0...applesauce-v0.5.1) - 2024-04-15
+
+### Added
+- Reset directory modified times as well
+
+### Other
+- Update readme with better install options
+- Appease clippy

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]


### PR DESCRIPTION
## 🤖 New release
* `applesauce`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `applesauce-cli`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`
<blockquote>

## [0.5.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.0...applesauce-v0.5.1) - 2024-04-15

### Added
- Reset directory modified times as well

### Other
- Update readme with better install options
- Appease clippy
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.0...applesauce-cli-v0.5.1) - 2024-04-15

### Added
- Reset directory modified times as well

### Other
- update Cargo.lock dependencies
- Update readme with better install options
- Appease clippy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).