### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "flate2",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.1...applesauce-cli-v0.5.2) - 2024-04-15
+
+### Other
+- Add benchmark to compare compressors
+- Do not compress a file inside a dir we're also compressing
+
 ## [0.5.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.0...applesauce-cli-v0.5.1) - 2024-04-15
 
 ### Added

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.5.1", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.5.2", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.0...applesauce-core-v0.3.1) - 2024-04-15
+
+### Other
+- Add benchmark to compare compressors

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.1...applesauce-v0.5.2) - 2024-04-15
+
+### Other
+- Add benchmark to compare compressors
+- Do not compress a file inside a dir we're also compressing
+
 ## [0.5.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.0...applesauce-v0.5.1) - 2024-04-15
 
 ### Added

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -25,7 +25,7 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 
 [dependencies]
 resource-fork = { version = "^0.3.0", path = "../resource-fork" }
-applesauce-core = { version = "^0.3.0", path = "../applesauce-core" }
+applesauce-core = { version = "^0.3.1", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.12"
 libc = "0.2.153"


### PR DESCRIPTION
## 🤖 New release
* `applesauce`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `applesauce-core`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `applesauce-cli`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`
<blockquote>

## [0.5.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.1...applesauce-v0.5.2) - 2024-04-15

### Other
- Add benchmark to compare compressors
- Do not compress a file inside a dir we're also compressing
</blockquote>

## `applesauce-core`
<blockquote>

## [0.3.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.0...applesauce-core-v0.3.1) - 2024-04-15

### Other
- Add benchmark to compare compressors
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.1...applesauce-cli-v0.5.2) - 2024-04-15

### Other
- Add benchmark to compare compressors
- Do not compress a file inside a dir we're also compressing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).