### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "applesauce",
  "cfg-if",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.2...applesauce-cli-v0.5.3) - 2024-04-16
+
+### Other
+- Only reset directories if we modify the contents
+- Save and restore created/added/modified/accessed times
+- Only reset a directory's times if it has files under it
+
 ## [0.5.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.1...applesauce-cli-v0.5.2) - 2024-04-15
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.5.2", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.5.3", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.2...applesauce-v0.5.3) - 2024-04-16
+
+### Other
+- Only reset directories if we modify the contents
+- Save and restore created/added/modified/accessed times
+- Only reset a directory's times if it has files under it
+
 ## [0.5.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.1...applesauce-v0.5.2) - 2024-04-15
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]


### PR DESCRIPTION
## 🤖 New release
* `applesauce`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `applesauce-cli`: 0.5.2 -> 0.5.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`
<blockquote>

## [0.5.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.2...applesauce-v0.5.3) - 2024-04-16

### Other
- Only reset directories if we modify the contents
- Save and restore created/added/modified/accessed times
- Only reset a directory's times if it has files under it
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.2...applesauce-cli-v0.5.3) - 2024-04-16

### Other
- Only reset directories if we modify the contents
- Save and restore created/added/modified/accessed times
- Only reset a directory's times if it has files under it
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).