### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "flate2",
@@ -847,7 +847,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.4...applesauce-cli-v0.5.5) - 2024-12-17
+
+### Other
+
+- Bump the minor-patches group across 1 directory with 3 updates ([#78](https://github.com/Dr-Emann/applesauce/pull/78))
+- fix clippy warnings
+
 ## [0.5.4](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.3...applesauce-cli-v0.5.4) - 2024-07-03
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.5.4", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.5.5", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.2...applesauce-core-v0.3.3) - 2024-12-17
+
+### Other
+
+- fix clippy warnings
+
 ## [0.3.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.1...applesauce-core-v0.3.2) - 2024-07-03
 
 ### Other

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.4...applesauce-v0.5.5) - 2024-12-17
+
+### Other
+
+- fix clippy warnings
+
 ## [0.5.4](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.3...applesauce-v0.5.4) - 2024-07-03
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.0", path = "../resource-fork" }
-applesauce-core = { version = "^0.3.2", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.1", path = "../resource-fork" }
+applesauce-core = { version = "^0.3.3", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.13"
 libc = "0.2.155"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.0...resource-fork-v0.3.1) - 2024-12-17
+
+### Other
+
+- fix clippy warnings

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION
## 🤖 New release
* `applesauce`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `applesauce-core`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `resource-fork`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `applesauce-cli`: 0.5.4 -> 0.5.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`
<blockquote>

## [0.5.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.4...applesauce-v0.5.5) - 2024-12-17

### Other

- fix clippy warnings
</blockquote>

## `applesauce-core`
<blockquote>

## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.2...applesauce-core-v0.3.3) - 2024-12-17

### Other

- fix clippy warnings
</blockquote>

## `resource-fork`
<blockquote>

## [0.3.1](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.0...resource-fork-v0.3.1) - 2024-12-17

### Other

- fix clippy warnings
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.4...applesauce-cli-v0.5.5) - 2024-12-17

### Other

- Bump the minor-patches group across 1 directory with 3 updates ([#78](https://github.com/Dr-Emann/applesauce/pull/78))
- fix clippy warnings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).