### PR TITLE
fix: avoid possible panic when verifying

### DIFF
--- a/crates/applesauce-cli/src/progress.rs
+++ b/crates/applesauce-cli/src/progress.rs
@@ -52,11 +52,16 @@ impl ProgressBars {
             .unwrap(),
             _ => write!(w, "-").unwrap(),
         };
+        #[allow(unknown_lints)] // TODO: Remove this once this clippy check is on stable
+        #[allow(clippy::literal_string_with_formatting_args)]
         let total_style = ProgressStyle::with_template(
             "{prefix:>25.bold} {wide_bar:.green} {bytes:>11}/{total_bytes:<11} {smoothed_eta:6}",
         )
         .unwrap()
         .with_key("smoothed_eta", smoothed_eta);
+
+        #[allow(unknown_lints)] // TODO: Remove this once this clippy check is on stable
+        #[allow(clippy::literal_string_with_formatting_args)]
         let style = ProgressStyle::with_template(
             "{prefix:>25.dim} {wide_bar} {bytes:>11}/{total_bytes:<11} {smoothed_eta:6}",
         )

--- a/crates/applesauce/src/threads/reader.rs
+++ b/crates/applesauce/src/threads/reader.rs
@@ -161,6 +161,15 @@ impl Handler {
         loop {
             let _enter = block_span.enter();
 
+            // make sure we don't reserve a slot if we won't be sending a chunk
+            if total_read == expected_len {
+                let mut buf = [0];
+                let n = try_read_all(file, &mut buf)?;
+                total_read += u64::try_from(n).unwrap();
+                // Outside the loop, we'll error if we read more than expected_len
+                break;
+            }
+
             let slot = {
                 let _enter = tracing::debug_span!("waiting for free slot").entered();
                 match tx.prepare_send() {


### PR DESCRIPTION
The chunk iterator ends when either the channel is closed, or a slot is left unfinished. Unfortunately, the reader was _always_ leaving a slot unfinished: after the final block was read, the reader would get another slot, read zero bytes to see the EOF, and drop the slot without filling it. This meant the writer would see the chunk iterator end when the slot was dropped, which meant the reader thread may not have gotten around to dropping the original file: the writer thread was assuming a finished iterator meant the channel was closed, but this was not the case.

So instead, check if we should expect we read the final block, and don't reserve a slot in that case to check if there's no more to read.

There's a more complete fix coming, but this will fix most realistic errors.

Fixes #97
Fixes #84