### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "flate2",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.5...applesauce-cli-v0.5.6) - 2025-01-02
+
+### Fixed
+- Avoid possible panic when verifying (by @Dr-Emann) - #98
+
+### Other
+- Appease clippy nightly (by @Dr-Emann) - #98
+
 ## [0.5.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.4...applesauce-cli-v0.5.5) - 2024-12-17
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.5.5", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.6.0", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.5...applesauce-v0.6.0) - 2025-01-02
+
+### Fixed
+- Avoid possible panic when verifying (by @Dr-Emann) - #98
+
 ## [0.5.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.4...applesauce-v0.5.5) - 2024-12-17
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -25,7 +25,7 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 
 [dependencies]
 resource-fork = { version = "^0.3.1", path = "../resource-fork" }
-applesauce-core = { version = "^0.3.3", path = "../applesauce-core" }
+applesauce-core = { version = "^0.3.4", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.13"
 libc = "0.2.155"


### PR DESCRIPTION
## 🤖 New release
* `applesauce`: 0.5.5 -> 0.6.0 (⚠️ API breaking changes)
* `applesauce-core`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `applesauce-cli`: 0.5.5 -> 0.5.6

### ⚠️ `applesauce` breaking changes

```
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/feature_missing.ron

Failed in:
  feature flate2 in the package's Cargo.toml
  feature lzfse-sys in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`
<blockquote>

## [0.6.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.5.5...applesauce-v0.6.0) - 2025-01-02

### Fixed
- Avoid possible panic when verifying (by @Dr-Emann) - #98
</blockquote>

## `applesauce-core`
<blockquote>

## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.2...applesauce-core-v0.3.3) - 2024-12-17

### Other

- fix clippy warnings
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.6](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.5...applesauce-cli-v0.5.6) - 2025-01-02

### Fixed
- Avoid possible panic when verifying (by @Dr-Emann) - #98

### Other
- Appease clippy nightly (by @Dr-Emann) - #98
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).