### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "applesauce",
  "cfg-if",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.8...applesauce-cli-v0.5.9) - 2025-01-06
+
+### Fixed
+- Correctly include skipped files in the final statistics (by @Dr-Emann) - #107
+
 ## [0.5.8](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.7...applesauce-cli-v0.5.8) - 2025-01-02
 
 ### Fixed

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.6.1", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.6.2", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.1...applesauce-v0.6.2) - 2025-01-06
+
+### Fixed
+- Correctly include skipped files in the final statistics (by @Dr-Emann) - #107
+
 ## [0.6.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.0...applesauce-v0.6.1) - 2025-01-02
 
 ### Fixed

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]


### PR DESCRIPTION
## 🤖 New release
* `applesauce`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `applesauce-cli`: 0.5.8 -> 0.5.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`
<blockquote>

## [0.6.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.1...applesauce-v0.6.2) - 2025-01-06

### Fixed
- Correctly include skipped files in the final statistics (by @Dr-Emann) - #107
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.9](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.8...applesauce-cli-v0.5.9) - 2025-01-06

### Fixed
- Correctly include skipped files in the final statistics (by @Dr-Emann) - #107
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).