### PR TITLE
fix: avoid re-fetching metadata for files which were not modified

### DIFF
--- a/crates/applesauce/src/threads/writer.rs
+++ b/crates/applesauce/src/threads/writer.rs
@@ -206,6 +206,7 @@ impl WorkHandler<WorkItem> for Handler {
         };
 
         if res.is_ok() {
+            context.report_new_stats();
             let compressing = context.operation.mode.is_compressing();
             let prefix = if compressing { "" } else { "de" };
             tracing::info!("Successfully {prefix}compressed {}", context.path.display());


### PR DESCRIPTION
This should slightly speed up the case when a lot of files end up not compressed.