### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "criterion",
  "flate2",

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.6.3", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.6.4", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.3...applesauce-v0.6.4) - 2025-02-01
+
+### Other
+- Updated the following local packages: applesauce-core
+
 ## [0.6.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.2...applesauce-v0.6.3) - 2025-02-01
 
 ### Fixed

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -25,7 +25,7 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 
 [dependencies]
 resource-fork = { version = "^0.3.1", path = "../resource-fork" }
-applesauce-core = { version = "^0.3.4", path = "../applesauce-core" }
+applesauce-core = { version = "^0.3.5", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.13"
 libc = "0.2.155"


### PR DESCRIPTION
## 🤖 New release
* `applesauce-core`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `applesauce-cli`: 0.5.10 -> 0.5.11
* `applesauce`: 0.6.3 -> 0.6.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`
<blockquote>

## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.2...applesauce-core-v0.3.3) - 2024-12-17

### Other

- fix clippy warnings
</blockquote>

## `applesauce-cli`
<blockquote>

## [0.5.10](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.9...applesauce-cli-v0.5.10) - 2025-02-01

### Fixed
- Avoid re-fetching metadata for files which were not modified (by @Dr-Emann) - #114
</blockquote>

## `applesauce`
<blockquote>

## [0.6.4](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.3...applesauce-v0.6.4) - 2025-02-01

### Other
- Updated the following local packages: applesauce-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).