### PR TITLE
feat: enable zlib levels up to 12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +91,6 @@ dependencies = [
  "applesauce",
  "cfg-if",
  "clap",
- "flate2",
  "humansize",
  "indicatif",
  "tikv-jemallocator",
@@ -111,10 +104,9 @@ name = "applesauce-core"
 version = "0.3.5"
 dependencies = [
  "criterion",
- "flate2",
  "libc",
+ "libdeflater",
  "lzfse-sys",
- "memchr",
  "rand",
  "tracing",
 ]
@@ -241,15 +233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmake"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,15 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -433,17 +407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
-dependencies = [
- "crc32fast",
- "libz-ng-sys",
- "miniz_oxide",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,20 +537,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libdeflate-sys"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b72ad3fbf5ac78f2df7b36075e48adf2459b57c150b9e63937d0204d0f9cd7"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "013344b17f9dceddff4872559ae19378bd8ee0479eccdd266d2dd2e894b4792f"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "libz-ng-sys"
-version = "1.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
-dependencies = [
- "cmake",
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -624,15 +595,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
-dependencies = [
- "adler2",
-]
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -152,9 +152,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -240,9 +240,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "encode_unicode"
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -532,9 +532,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libdeflate-sys"
@@ -568,9 +568,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lzfse-sys"
@@ -623,15 +623,15 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oneshot"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
+checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
 
 [[package]]
 name = "oorandom"
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "ppv-lite86"
@@ -696,18 +696,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -720,7 +720,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy 0.8.14",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -735,12 +735,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
- "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -831,15 +830,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -852,18 +851,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -872,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -910,9 +909,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "strsim"
@@ -922,9 +921,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -933,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1059,15 +1058,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -1315,11 +1314,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.14"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
 dependencies = [
- "zerocopy-derive 0.8.14",
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -1335,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.14"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [features]
 default = ["zlib", "lzfse", "lzvn"]
 
-zlib = ["applesauce/zlib", "dep:flate2"]
+zlib = ["applesauce/zlib"]
 lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
@@ -30,5 +30,3 @@ tikv-jemallocator = "0.6"
 tracing = "0.1"
 tracing-chrome = "0.7"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
-
-flate2 = { version = "1.0", optional = true, features = ["zlib-ng"], default-features = false }

--- a/crates/applesauce-cli/src/main.rs
+++ b/crates/applesauce-cli/src/main.rs
@@ -93,7 +93,7 @@ struct Compress {
     #[arg(
         short, long,
         default_value_t = 5,
-        value_parser = clap::value_parser!(u32).range(1..=9)
+        value_parser = clap::value_parser!(u32).range(1..=12)
     )]
     level: u32,
 
@@ -181,16 +181,7 @@ fn chrome_tracing_file(path: Option<&Path>) -> Option<impl io::Write> {
         }
     };
 
-    let writer = {
-        cfg_if! {
-            if #[cfg(feature = "zlib")] {
-                flate2::write::GzEncoder::new(file, flate2::Compression::default())
-            } else {
-                file
-            }
-        }
-    };
-    Some(BufWriter::new(writer))
+    Some(BufWriter::new(file))
 }
 
 fn main() {

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../../README.md"
 [features]
 default = ["zlib", "lzfse", "lzvn"]
 
-zlib = ["dep:flate2"]
+zlib = ["dep:libdeflater"]
 lzfse = ["dep:lzfse-sys"]
 lzvn = ["dep:lzfse-sys"]
 
@@ -23,10 +23,8 @@ system-lzfse = ["lzfse"]
 
 [dependencies]
 libc = "0.2.155"
-memchr = "2.7"
 tracing = "0.1.40"
-
-flate2 = { version = "1.0", optional = true }
+libdeflater = { version = "1.23.0", optional = true }
 
 # pin to an exact version, since we depend on internal implementation details
 lzfse-sys = { version = "=2.0.0", optional = true }

--- a/crates/applesauce-core/src/compressor/mod.rs
+++ b/crates/applesauce-core/src/compressor/mod.rs
@@ -45,7 +45,7 @@ impl Compressor {
     #[cfg(feature = "zlib")]
     #[must_use]
     pub fn zlib() -> Self {
-        Self(Data::Zlib(Zlib))
+        Self(Data::Zlib(Zlib::new()))
     }
 
     #[cfg(feature = "lzfse")]
@@ -160,7 +160,7 @@ impl Kind {
     pub fn compressor(self) -> Option<Compressor> {
         let data = match self {
             #[cfg(feature = "zlib")]
-            Kind::Zlib => Data::Zlib(Zlib),
+            Kind::Zlib => Data::Zlib(Zlib::new()),
             #[cfg(feature = "lzfse")]
             Kind::Lzfse => Data::Lzfse(Lzfse::new()),
             #[cfg(feature = "lzvn")]

--- a/crates/applesauce-core/src/compressor/zlib.rs
+++ b/crates/applesauce-core/src/compressor/zlib.rs
@@ -170,9 +170,9 @@ impl super::CompressorImpl for Zlib {
             };
             writer.write_all(&block_info.to_bytes())?;
 
-            current_offset = current_offset.checked_add(size).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::Other, "offset too large for 32 bytes")
-            })?;
+            current_offset = current_offset
+                .checked_add(size)
+                .ok_or_else(|| io::Error::other("offset too large for 32 bytes"))?;
         }
 
         writer.flush()?;

--- a/crates/applesauce-core/src/lib.rs
+++ b/crates/applesauce-core/src/lib.rs
@@ -1,6 +1,3 @@
-use std::io;
-use std::io::Read;
-
 pub mod compressor;
 pub mod decmpfs;
 pub mod reader;
@@ -25,37 +22,4 @@ pub const fn round_to_block_size(size: u64, block_size: u64) -> u64 {
         0 => size,
         r => size + (block_size - r),
     }
-}
-
-/// Try to read `buf.len()` bytes from `r`, returning the number of bytes read.
-///
-/// This function will only return partial reads if EOF is reached before
-/// reading all bytes.
-fn try_read_all<R: Read>(mut r: R, buf: &mut [u8]) -> io::Result<usize> {
-    let bulk_read_span = tracing::trace_span!(
-        "try_read_all",
-        len = buf.len(),
-        read_len = tracing::field::Empty,
-    );
-    let full_len = buf.len();
-    let mut remaining = buf;
-    loop {
-        let _enter = bulk_read_span.enter();
-        let n = match r.read(remaining) {
-            Ok(n) => n,
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(e),
-        };
-        if n == 0 {
-            break;
-        }
-        remaining = &mut remaining[n..];
-        if remaining.is_empty() {
-            return Ok(full_len);
-        }
-    }
-    let read_len = full_len - remaining.len();
-
-    bulk_read_span.record("read_len", read_len);
-    Ok(read_len)
 }

--- a/crates/applesauce-core/src/reader.rs
+++ b/crates/applesauce-core/src/reader.rs
@@ -44,12 +44,7 @@ impl<R: Read + Seek> Reader<R> {
             .compression_type
             .compression_storage()
             .filter(|(kind, _)| kind.supported())
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    "unsupported compression kind or storage",
-                )
-            })?;
+            .ok_or_else(|| io::Error::other("unsupported compression kind or storage"))?;
         let state = match storage {
             Storage::Xattr => State::Xattr(Cursor::new(decmpfs_value.extra_data.to_vec())),
             Storage::ResourceFork => {

--- a/crates/applesauce/src/info.rs
+++ b/crates/applesauce/src/info.rs
@@ -237,13 +237,10 @@ pub fn get(path: &Path) -> io::Result<AfscFileInfo> {
         } else {
             let maybe_len = xattr::len(&path, xattr_name)?;
             let len = maybe_len.ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "file claimed to have xattr '{}', but it has no len",
-                        xattr_name.to_string_lossy()
-                    ),
-                )
+                io::Error::other(format!(
+                    "file claimed to have xattr '{}', but it has no len",
+                    xattr_name.to_string_lossy()
+                ))
             })?;
             let len = u64::try_from(len).unwrap();
 
@@ -272,8 +269,7 @@ pub fn get(path: &Path) -> io::Result<AfscFileInfo> {
 
 fn get_decmpfs_info(path: &CStr) -> io::Result<Result<DecmpfsInfo, decmpfs::DecodeError>> {
     let maybe_data = xattr::read(path, decmpfs::XATTR_NAME)?;
-    let data = maybe_data
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "cannot get decmpfs xattr"))?;
+    let data = maybe_data.ok_or_else(|| io::Error::other("cannot get decmpfs xattr"))?;
 
     Ok(decmpfs_info_from_bytes(&data))
 }

--- a/crates/applesauce/src/rfork_storage.rs
+++ b/crates/applesauce/src/rfork_storage.rs
@@ -12,7 +12,7 @@ where
     F2: FnMut(&[u8]) -> io::Result<()>,
 {
     let decmpfs_data = xattr::read(file, decmpfs::XATTR_NAME)?
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "file is not compressed"))?;
+        .ok_or_else(|| io::Error::other("file is not compressed"))?;
     let mut reader =
         applesauce_core::reader::Reader::new(&decmpfs_data, || ResourceFork::new(file))?;
 

--- a/crates/applesauce/src/seq_queue.rs
+++ b/crates/applesauce/src/seq_queue.rs
@@ -14,7 +14,7 @@ impl std::error::Error for UnknownError {}
 
 impl From<UnknownError> for io::Error {
     fn from(value: UnknownError) -> Self {
-        io::Error::new(io::ErrorKind::Other, value)
+        io::Error::other(value)
     }
 }
 

--- a/crates/applesauce/src/threads/reader.rs
+++ b/crates/applesauce/src/threads/reader.rs
@@ -69,9 +69,9 @@ impl Handler {
                     move |data| {
                         // TODO: This waits for a slot after we have already read.
                         // TODO: This should be able to exit early, without an error
-                        let slot = tx.prepare_send().ok_or_else(|| {
-                            io::Error::new(io::ErrorKind::Other, "error must have occurred writing")
-                        })?;
+                        let slot = tx
+                            .prepare_send()
+                            .ok_or_else(|| io::Error::other("error must have occurred writing"))?;
                         let _enter =
                             tracing::debug_span!("waiting to send to compressor").entered();
                         self.compressor
@@ -151,10 +151,7 @@ impl Handler {
                 }
                 total_read += u64::try_from(n).unwrap();
                 if total_read > expected_len {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "file size changed while reading",
-                    ));
+                    return Err(io::Error::other("file size changed while reading"));
                 }
                 buf.truncate(n);
                 buf
@@ -164,10 +161,7 @@ impl Handler {
         }
         if total_read != expected_len {
             // The writer will be notified by returning an error
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "file size changed while reading",
-            ));
+            return Err(io::Error::other("file size changed while reading"));
         }
         Ok(true)
     }

--- a/crates/applesauce/src/threads/writer.rs
+++ b/crates/applesauce/src/threads/writer.rs
@@ -75,13 +75,10 @@ impl Handler {
             total_compressed_size += u64::try_from(chunk.block.len()).unwrap();
             if total_compressed_size > max_compressed_size {
                 context.progress.not_compressible_enough(&context.path);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "did not compress to at least {}% of original size",
-                        minimum_compression_ratio * 100.0
-                    ),
-                ));
+                return Err(io::Error::other(format!(
+                    "did not compress to at least {}% of original size",
+                    minimum_compression_ratio * 100.0
+                )));
             }
 
             let Chunk { block, orig_size } = chunk;
@@ -141,13 +138,10 @@ impl Handler {
             new_file.rewind()?;
 
             ensure_identical_files(orig_file, new_file).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "verification failed: {e}, {} unchanged",
-                        item.context.path.display()
-                    ),
-                )
+                io::Error::other(format!(
+                    "verification failed: {e}, {} unchanged",
+                    item.context.path.display()
+                ))
             })?;
         }
 

--- a/crates/applesauce/src/xattr.rs
+++ b/crates/applesauce/src/xattr.rs
@@ -275,12 +275,8 @@ pub fn with_names<T: XattrSource + ?Sized, F: FnMut(&CStr) -> io::Result<()>>(
     let mut raw_buf = &raw_buf[..];
 
     while !raw_buf.is_empty() {
-        let next_end = memchr(b'\0', raw_buf).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "expected null terminator in xattr names",
-            )
-        })?;
+        let next_end = memchr(b'\0', raw_buf)
+            .ok_or_else(|| io::Error::other("expected null terminator in xattr names"))?;
         let end_including_term = next_end + 1;
         let name = CStr::from_bytes_with_nul(&raw_buf[..end_including_term])
             .expect("Found the first null, cannot be interior or missing null char");

--- a/crates/resource-fork/src/lib.rs
+++ b/crates/resource-fork/src/lib.rs
@@ -72,12 +72,10 @@ impl io::Write for ResourceFork<'_> {
             .len()
             .try_into()
             .map_err(|_| io::ErrorKind::InvalidInput)?;
-        let end_offset = self.position.checked_add(len).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "unable to fit resource fork in 32 bits",
-            )
-        })?;
+        let end_offset = self
+            .position
+            .checked_add(len)
+            .ok_or_else(|| io::Error::other("unable to fit resource fork in 32 bits"))?;
         // SAFETY:
         // fd is valid
         // xattr name is valid


### PR DESCRIPTION
Use [libdeflate](via [libdeflater] for zlib compression, which tries to be slightly faster, and improve on the compression ratio at the same compression level. Additionally, allow compression levels up to 12, which can improve even further on the compression ratio (at the expense of being quite a bit slower).

[libdeflate]: https://github.com/ebiggers/libdeflate
[libdeflater]: https://github.com/adamkewley/libdeflater