### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "libc",
@@ -808,7 +808,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.11...applesauce-cli-v0.5.12) - 2025-03-05
+
+### Added
+- Enable zlib levels up to 12 (by @Dr-Emann) - #127
+
+### Other
+- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
+
 ## [0.5.10](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.9...applesauce-cli-v0.5.10) - 2025-02-01
 
 ### Fixed

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.6.4", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.6.5", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.5...applesauce-core-v0.4.0) - 2025-03-05
+
+### Added
+- Enable zlib levels up to 12 (by @Dr-Emann) - #127
+
+### Other
+- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
+
 ## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.2...applesauce-core-v0.3.3) - 2024-12-17
 
 ### Other

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.4...applesauce-v0.6.5) - 2025-03-05
+
+### Other
+- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
+
 ## [0.6.4](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.3...applesauce-v0.6.4) - 2025-02-01
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.1", path = "../resource-fork" }
-applesauce-core = { version = "^0.3.5", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.2", path = "../resource-fork" }
+applesauce-core = { version = "^0.4.0", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.13"
 libc = "0.2.155"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.1...resource-fork-v0.3.2) - 2025-03-05
+
+### Other
+- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
+
 ## [0.3.1](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.0...resource-fork-v0.3.1) - 2024-12-17
 
 ### Other

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.3.5 -> 0.4.0 (⚠ API breaking changes)
* `resource-fork`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `applesauce`: 0.6.4 -> 0.6.5 (✓ API compatible changes)
* `applesauce-cli`: 0.5.11 -> 0.5.12

### ⚠ `applesauce-core` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Compressor is no longer Sync, in /private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/.tmpa1Kvr3/applesauce/crates/applesauce-core/src/compressor/mod.rs:42
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>

## [0.4.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.5...applesauce-core-v0.4.0) - 2025-03-05

### Added
- Enable zlib levels up to 12 (by @Dr-Emann) - #127

### Other
- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
</blockquote>

## `resource-fork`

<blockquote>

## [0.3.2](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.1...resource-fork-v0.3.2) - 2025-03-05

### Other
- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
</blockquote>

## `applesauce`

<blockquote>

## [0.6.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.4...applesauce-v0.6.5) - 2025-03-05

### Other
- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.12](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.11...applesauce-cli-v0.5.12) - 2025-03-05

### Added
- Enable zlib levels up to 12 (by @Dr-Emann) - #127

### Other
- Use io::Error::other where possible, fix nightly clippy warnings (by @Dr-Emann) - #127
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).