### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "libc",
@@ -801,7 +801,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.14](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.13...applesauce-cli-v0.5.14) - 2025-04-28
+
+### Other
+- Fix clippy warnings on nightly (by @Dr-Emann) - #141
+- *(deps)* Bump the minor-patches group with 3 updates (by @dependabot[bot]) - #140
+- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #138
+
 ## [0.5.13](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.12...applesauce-cli-v0.5.13) - 2025-03-14
 
 ### Fixed

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.6.6", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.6.7", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.0...applesauce-core-v0.4.1) - 2025-04-28
+
+### Other
+- *(deps)* Bump the minor-patches group with 3 updates (by @dependabot[bot]) - #140
+
 ## [0.4.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.3.5...applesauce-core-v0.4.0) - 2025-03-05
 
 ### Added

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.7](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.6...applesauce-v0.6.7) - 2025-04-28
+
+### Other
+- *(deps)* Bump the minor-patches group with 3 updates (by @dependabot[bot]) - #140
+- Fix clippy warnings on nightly (by @Dr-Emann) - #141
+- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #138
+
 ## [0.6.6](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.5...applesauce-v0.6.6) - 2025-03-14
 
 ### Fixed

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.2", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.0", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.3", path = "../resource-fork" }
+applesauce-core = { version = "^0.4.1", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.172"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.2...resource-fork-v0.3.3) - 2025-04-28
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #138
+
 ## [0.3.2](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.1...resource-fork-v0.3.2) - 2025-03-05
 
 ### Other

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `resource-fork`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `applesauce`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `applesauce-cli`: 0.5.13 -> 0.5.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>

## [0.4.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.0...applesauce-core-v0.4.1) - 2025-04-28

### Other
- *(deps)* Bump the minor-patches group with 3 updates (by @dependabot[bot]) - #140
</blockquote>

## `resource-fork`

<blockquote>

## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.2...resource-fork-v0.3.3) - 2025-04-28

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #138
</blockquote>

## `applesauce`

<blockquote>

## [0.6.7](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.6...applesauce-v0.6.7) - 2025-04-28

### Other
- *(deps)* Bump the minor-patches group with 3 updates (by @dependabot[bot]) - #140
- Fix clippy warnings on nightly (by @Dr-Emann) - #141
- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #138
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.14](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.13...applesauce-cli-v0.5.14) - 2025-04-28

### Other
- Fix clippy warnings on nightly (by @Dr-Emann) - #141
- *(deps)* Bump the minor-patches group with 3 updates (by @dependabot[bot]) - #140
- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #138
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).