### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "libc",
@@ -790,7 +790,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.15](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.14...applesauce-cli-v0.5.15) - 2025-07-08
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #150
+- Fix clippy warnings on nightly (by @Dr-Emann) - #153
+- *(deps)* Bump libc in the minor-patches group (by @dependabot[bot]) - #151
+- Fix clippy warnings on nightly (by @Dr-Emann) - #148
+- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
+
 ## [0.5.14](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.13...applesauce-cli-v0.5.14) - 2025-04-28
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.14"
+version = "0.5.15"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.6.7", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.6.8", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.1...applesauce-core-v0.4.2) - 2025-07-08
+
+### Other
+- Fix clippy warnings on nightly (by @Dr-Emann) - #153
+- *(deps)* Bump libc in the minor-patches group (by @dependabot[bot]) - #151
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #150
+- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
+
 ## [0.4.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.0...applesauce-core-v0.4.1) - 2025-04-28
 
 ### Other

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.8](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.7...applesauce-v0.6.8) - 2025-07-08
+
+### Other
+- Fix clippy warnings on nightly (by @Dr-Emann) - #153
+- *(deps)* Bump libc in the minor-patches group (by @dependabot[bot]) - #151
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #150
+- Fix clippy warnings on nightly (by @Dr-Emann) - #148
+- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
+
 ## [0.6.7](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.6...applesauce-v0.6.7) - 2025-04-28
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.3", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.1", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.4", path = "../resource-fork" }
+applesauce-core = { version = "^0.4.2", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.174"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.3...resource-fork-v0.3.4) - 2025-07-08
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
+
 ## [0.3.3](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.2...resource-fork-v0.3.3) - 2025-04-28
 
 ### Other

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `resource-fork`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `applesauce`: 0.6.7 -> 0.6.8 (✓ API compatible changes)
* `applesauce-cli`: 0.5.14 -> 0.5.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>

## [0.4.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.1...applesauce-core-v0.4.2) - 2025-07-08

### Other
- Fix clippy warnings on nightly (by @Dr-Emann) - #153
- *(deps)* Bump libc in the minor-patches group (by @dependabot[bot]) - #151
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #150
- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
</blockquote>

## `resource-fork`

<blockquote>

## [0.3.4](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.3...resource-fork-v0.3.4) - 2025-07-08

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
</blockquote>

## `applesauce`

<blockquote>

## [0.6.8](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.7...applesauce-v0.6.8) - 2025-07-08

### Other
- Fix clippy warnings on nightly (by @Dr-Emann) - #153
- *(deps)* Bump libc in the minor-patches group (by @dependabot[bot]) - #151
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #150
- Fix clippy warnings on nightly (by @Dr-Emann) - #148
- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.15](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.14...applesauce-cli-v0.5.15) - 2025-07-08

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #150
- Fix clippy warnings on nightly (by @Dr-Emann) - #153
- *(deps)* Bump libc in the minor-patches group (by @dependabot[bot]) - #151
- Fix clippy warnings on nightly (by @Dr-Emann) - #148
- *(deps)* Bump the minor-patches group across 1 directory with 5 updates (by @dependabot[bot]) - #145
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).