### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.17](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.16...applesauce-cli-v0.5.17) - 2025-07-12
+
+### Added
+- Refuse to break hard links (by @Dr-Emann) - #158
+- Make make creating lz compressors a little cheaper (by @Dr-Emann) - #156
+
 ## [0.5.16](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.15...applesauce-cli-v0.5.16) - 2025-07-10
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.16"
+version = "0.5.17"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.6.8", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.7.0", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.2...applesauce-core-v0.4.3) - 2025-07-12
+
+### Added
+- Make make creating lz compressors a little cheaper (by @Dr-Emann) - #156
+
 ## [0.4.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.1...applesauce-core-v0.4.2) - 2025-07-08
 
 ### Other

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.8...applesauce-v0.7.0) - 2025-07-12
+
+### Added
+- Refuse to break hard links (by @Dr-Emann) - #158
+
 ## [0.6.8](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.7...applesauce-v0.6.8) - 2025-07-08
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.6.8"
+version = "0.7.0"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -25,7 +25,7 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 
 [dependencies]
 resource-fork = { version = "^0.3.4", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.2", path = "../applesauce-core" }
+applesauce-core = { version = "^0.4.3", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.174"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `applesauce`: 0.6.8 -> 0.7.0 (⚠ API breaking changes)
* `applesauce-cli`: 0.5.16 -> 0.5.17

### ⚠ `applesauce` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant SkipReason:HardLink in /private/var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/.tmpEYJVnv/applesauce/crates/applesauce/src/progress.rs:16
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>

## [0.4.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.2...applesauce-core-v0.4.3) - 2025-07-12

### Added
- Make make creating lz compressors a little cheaper (by @Dr-Emann) - #156
</blockquote>

## `applesauce`

<blockquote>

## [0.7.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.8...applesauce-v0.7.0) - 2025-07-12

### Added
- Refuse to break hard links (by @Dr-Emann) - #158
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.17](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.16...applesauce-cli-v0.5.17) - 2025-07-12

### Added
- Refuse to break hard links (by @Dr-Emann) - #158
- Make make creating lz compressors a little cheaper (by @Dr-Emann) - #156
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).