### PR TITLE
feat: refuse to break hard links

### DIFF
--- a/crates/applesauce-cli/src/progress.rs
+++ b/crates/applesauce-cli/src/progress.rs
@@ -151,7 +151,8 @@ impl Progress for ProgressBars {
             | SkipReason::ReadError(_)
             | SkipReason::ZfsFilesystem
             | SkipReason::HasRequiredXattr
-            | SkipReason::FsNotSupported => Verbosity::Normal,
+            | SkipReason::FsNotSupported
+            | SkipReason::HardLink => Verbosity::Normal,
         };
         if self.verbosity >= required_verbosity {
             self.total_bar

--- a/crates/applesauce/src/progress.rs
+++ b/crates/applesauce/src/progress.rs
@@ -13,6 +13,7 @@ pub enum SkipReason {
     ZfsFilesystem,
     HasRequiredXattr,
     FsNotSupported,
+    HardLink,
 }
 
 impl From<IncompressibleReason> for SkipReason {
@@ -83,6 +84,7 @@ impl fmt::Display for SkipReason {
             SkipReason::HasRequiredXattr => write!(f, "Compression xattrs already present"),
             SkipReason::FsNotSupported => write!(f, "Filesystem does not support compression"),
             SkipReason::EmptyFile => write!(f, "Empty file"),
+            SkipReason::HardLink => write!(f, "Other hard links exist to file"),
         }
     }
 }


### PR DESCRIPTION
Because we write to a temporary file, then atomically replace the original file, doing so on a file that has hard link(s) would break those links (the other files would not be updated, and any future writes to this or those links would no longer update the other links).

In order to avoid the posibility that could cause breakage, cowardly refuse to compress(or decompress) files with hardlinks.

Fixes #62, currently unconditionally skip files with hardlinks.

See also #61, which would allow us to theoretically write through to the hardlinks, but unsafely.

Reminded by https://github.com/RJVB/afsctool/issues/63#issuecomment-3061581076