### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "criterion",
  "libc",
@@ -775,7 +775,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.18](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.17...applesauce-cli-v0.5.18) - 2025-08-02
+
+### Other
+- Update Cargo.lock dependencies
+- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #161
+
 ## [0.5.17](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.16...applesauce-cli-v0.5.17) - 2025-07-12
 
 ### Added

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.7.0", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.7.1", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.4](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.3...applesauce-core-v0.4.4) - 2025-08-02
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #161
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.7.0...applesauce-v0.7.1) - 2025-08-02
+
+### Other
+- Updated the following local packages: applesauce-core, resource-fork
+
 ## [0.7.0](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.6.8...applesauce-v0.7.0) - 2025-07-12
 
 ### Added

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.4", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.3", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.5", path = "../resource-fork" }
+applesauce-core = { version = "^0.4.4", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.174"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.4...resource-fork-v0.3.5) - 2025-08-02
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #161
+
 ## [0.3.4](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.3...resource-fork-v0.3.4) - 2025-07-08
 
 ### Other

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `resource-fork`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `applesauce-cli`: 0.5.17 -> 0.5.18
* `applesauce`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `resource-fork`

<blockquote>

## [0.3.5](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.4...resource-fork-v0.3.5) - 2025-08-02

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #161
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.18](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.17...applesauce-cli-v0.5.18) - 2025-08-02

### Other
- Update Cargo.lock dependencies
- *(deps)* Bump the minor-patches group across 1 directory with 3 updates (by @dependabot[bot]) - #161
</blockquote>

## `applesauce`

<blockquote>

## [0.7.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.7.0...applesauce-v0.7.1) - 2025-08-02

### Other
- Updated the following local packages: applesauce-core, resource-fork
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).