### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "criterion",
  "libc",
@@ -772,7 +772,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.19](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.18...applesauce-cli-v0.5.19) - 2025-09-14
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
+
 ## [0.5.18](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.17...applesauce-cli-v0.5.18) - 2025-08-02
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.18"
+version = "0.5.19"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.7.1", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.7.2", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.3"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.4...applesauce-core-v0.4.5) - 2025-09-14
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
+
 ## [0.4.3](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.2...applesauce-core-v0.4.3) - 2025-07-12
 
 ### Added

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.7.1...applesauce-v0.7.2) - 2025-09-14
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
+
 ## [0.7.1](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.7.0...applesauce-v0.7.1) - 2025-08-02
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.5", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.4", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.6", path = "../resource-fork" }
+applesauce-core = { version = "^0.4.5", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.175"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.5...resource-fork-v0.3.6) - 2025-09-14
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
+
 ## [0.3.5](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.4...resource-fork-v0.3.5) - 2025-08-02
 
 ### Other

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `resource-fork`: 0.3.5 -> 0.3.6 (✓ API compatible changes)
* `applesauce`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `applesauce-cli`: 0.5.18 -> 0.5.19

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>


## [0.4.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.4...applesauce-core-v0.4.5) - 2025-09-14

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
</blockquote>

## `resource-fork`

<blockquote>

## [0.3.6](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.5...resource-fork-v0.3.6) - 2025-09-14

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
</blockquote>

## `applesauce`

<blockquote>

## [0.7.2](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.7.1...applesauce-v0.7.2) - 2025-09-14

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.19](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.18...applesauce-cli-v0.5.19) - 2025-09-14

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #167
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).