### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "applesauce"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "criterion",
  "libc",
@@ -914,7 +914,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "resource-fork"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.26](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.25...applesauce-cli-v0.5.26) - 2026-04-06
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
+- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
+
 ## [0.5.25](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.24...applesauce-cli-v0.5.25) - 2026-02-23
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.25"
+version = "0.5.26"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.8.5", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.8.6", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.4"
 clap = { version = "4.6", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.10...applesauce-core-v0.4.11) - 2026-04-06
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
+- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
+
 ## [0.4.10](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.9...applesauce-core-v0.4.10) - 2026-02-23
 
 ### Other

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.5...applesauce-v0.8.6) - 2026-04-06
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
+- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
+
 ## [0.8.5](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.4...applesauce-v0.8.5) - 2026-02-23
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -24,8 +24,8 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-resource-fork = { version = "^0.3.9", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.10", path = "../applesauce-core" }
+resource-fork = { version = "^0.3.10", path = "../resource-fork" }
+applesauce-core = { version = "^0.4.11", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.184"

--- a/crates/resource-fork/CHANGELOG.md
+++ b/crates/resource-fork/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.9...resource-fork-v0.3.10) - 2026-04-06
+
+### Other
+- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
+- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
+
 ## [0.3.9](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.8...resource-fork-v0.3.9) - 2026-02-16
 
 ### Other

--- a/crates/resource-fork/Cargo.toml
+++ b/crates/resource-fork/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resource-fork"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A library for reading and writing Macos resource forks"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.10 -> 0.4.11 (✓ API compatible changes)
* `resource-fork`: 0.3.9 -> 0.3.10 (✓ API compatible changes)
* `applesauce`: 0.8.5 -> 0.8.6 (✓ API compatible changes)
* `applesauce-cli`: 0.5.25 -> 0.5.26

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>


## [0.4.11](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.10...applesauce-core-v0.4.11) - 2026-04-06

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
</blockquote>

## `resource-fork`

<blockquote>

## [0.3.10](https://github.com/Dr-Emann/applesauce/compare/resource-fork-v0.3.9...resource-fork-v0.3.10) - 2026-04-06

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
</blockquote>

## `applesauce`

<blockquote>

## [0.8.6](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.5...applesauce-v0.8.6) - 2026-04-06

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.26](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.25...applesauce-cli-v0.5.26) - 2026-04-06

### Other
- *(deps)* Bump the minor-patches group across 1 directory with 4 updates (by @dependabot[bot]) - #226
- *(deps)* Bump the minor-patches group across 1 directory with 2 updates (by @dependabot[bot]) - #223
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).