### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "applesauce"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.26"
+version = "0.5.27"
 dependencies = [
  "applesauce",
  "cfg-if",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-core"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "criterion",
  "libc",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.27](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.26...applesauce-cli-v0.5.27) - 2026-04-28
+
+### Other
+- Update Cargo.lock dependencies
+- *(deps)* Update oneshot library to 0.2 (by @Dr-Emann) - #232
+- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #231
+- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 (by @dependabot[bot]) - #229
+- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #228
+
 ## [0.5.26](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.25...applesauce-cli-v0.5.26) - 2026-04-06
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.26"
+version = "0.5.27"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.8.6", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.8.7", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.4"
 clap = { version = "4.6", features = ["derive"] }

--- a/crates/applesauce-core/CHANGELOG.md
+++ b/crates/applesauce-core/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.12](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.11...applesauce-core-v0.4.12) - 2026-04-28
+
+### Other
+- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #231
+- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #228
+
 ## [0.4.11](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.10...applesauce-core-v0.4.11) - 2026-04-06
 
 ### Other

--- a/crates/applesauce-core/Cargo.toml
+++ b/crates/applesauce-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-core"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A low level library interface for compressing and decompressing files using macos transparent compression"

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.6...applesauce-v0.8.7) - 2026-04-28
+
+### Other
+- *(deps)* Update oneshot library to 0.2 (by @Dr-Emann) - #232
+- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #231
+- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 (by @dependabot[bot]) - #229
+- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #228
+
 ## [0.8.6](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.5...applesauce-v0.8.6) - 2026-04-06
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]
@@ -25,7 +25,7 @@ system-lzfse = ["lzfse", "applesauce-core/system-lzfse"]
 
 [dependencies]
 resource-fork = { version = "^0.3.10", path = "../resource-fork" }
-applesauce-core = { version = "^0.4.11", path = "../applesauce-core" }
+applesauce-core = { version = "^0.4.12", path = "../applesauce-core" }
 
 crossbeam-channel = "0.5.15"
 libc = "0.2.186"


### PR DESCRIPTION



## 🤖 New release

* `applesauce-core`: 0.4.11 -> 0.4.12 (✓ API compatible changes)
* `applesauce`: 0.8.6 -> 0.8.7 (✓ API compatible changes)
* `applesauce-cli`: 0.5.26 -> 0.5.27

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce-core`

<blockquote>


## [0.4.12](https://github.com/Dr-Emann/applesauce/compare/applesauce-core-v0.4.11...applesauce-core-v0.4.12) - 2026-04-28

### Other
- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #231
- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #228
</blockquote>

## `applesauce`

<blockquote>

## [0.8.7](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.6...applesauce-v0.8.7) - 2026-04-28

### Other
- *(deps)* Update oneshot library to 0.2 (by @Dr-Emann) - #232
- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #231
- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 (by @dependabot[bot]) - #229
- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #228
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.27](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.26...applesauce-cli-v0.5.27) - 2026-04-28

### Other
- Update Cargo.lock dependencies
- *(deps)* Update oneshot library to 0.2 (by @Dr-Emann) - #232
- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #231
- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 (by @dependabot[bot]) - #229
- *(deps)* Bump the minor-patches group with 2 updates (by @dependabot[bot]) - #228
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).