### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "applesauce"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "applesauce-core",
  "crossbeam-channel",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "applesauce-cli"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "applesauce",
  "cfg-if",

--- a/crates/applesauce-cli/CHANGELOG.md
+++ b/crates/applesauce-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.28](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.27...applesauce-cli-v0.5.28) - 2026-06-02
+
+### Other
+- *(deps)* Bump tikv-jemallocator from 0.6.1 to 0.7.0 (by @dependabot[bot]) - #237
+- *(deps)* Bump dashmap from 6.1.0 to 6.2.1 in the minor-patches group (by @dependabot[bot]) - #234
+
 ## [0.5.27](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.26...applesauce-cli-v0.5.27) - 2026-04-28
 
 ### Other

--- a/crates/applesauce-cli/Cargo.toml
+++ b/crates/applesauce-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "applesauce-cli"
-version = "0.5.27"
+version = "0.5.28"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A command-line interface for compressing and decompressing files using macos transparent compression"
@@ -20,7 +20,7 @@ lzfse = ["applesauce/lzfse"]
 lzvn = ["applesauce/lzvn"]
 
 [dependencies]
-applesauce = { version = "^0.8.7", path = "../applesauce", default-features = false }
+applesauce = { version = "^0.8.8", path = "../applesauce", default-features = false }
 
 cfg-if = "1.0.4"
 clap = { version = "4.6", features = ["derive"] }

--- a/crates/applesauce/CHANGELOG.md
+++ b/crates/applesauce/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.8](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.7...applesauce-v0.8.8) - 2026-06-02
+
+### Other
+- *(deps)* Bump dashmap from 6.1.0 to 6.2.1 in the minor-patches group (by @dependabot[bot]) - #234
+
 ## [0.8.7](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.6...applesauce-v0.8.7) - 2026-04-28
 
 ### Other

--- a/crates/applesauce/Cargo.toml
+++ b/crates/applesauce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "applesauce"
 description = "A tool for compressing files with apple file system compression"
 license = "GPL-3.0-or-later"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 keywords = ["compression", "afsc", "decmpfs"]
 categories = ["compression"]


### PR DESCRIPTION



## 🤖 New release

* `applesauce`: 0.8.7 -> 0.8.8 (✓ API compatible changes)
* `applesauce-cli`: 0.5.27 -> 0.5.28

<details><summary><i><b>Changelog</b></i></summary><p>

## `applesauce`

<blockquote>

## [0.8.8](https://github.com/Dr-Emann/applesauce/compare/applesauce-v0.8.7...applesauce-v0.8.8) - 2026-06-02

### Other
- *(deps)* Bump dashmap from 6.1.0 to 6.2.1 in the minor-patches group (by @dependabot[bot]) - #234
</blockquote>

## `applesauce-cli`

<blockquote>

## [0.5.28](https://github.com/Dr-Emann/applesauce/compare/applesauce-cli-v0.5.27...applesauce-cli-v0.5.28) - 2026-06-02

### Other
- *(deps)* Bump tikv-jemallocator from 0.6.1 to 0.7.0 (by @dependabot[bot]) - #237
- *(deps)* Bump dashmap from 6.1.0 to 6.2.1 in the minor-patches group (by @dependabot[bot]) - #234
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).