### PR TITLE
Skip already-compressed files after first block

### DIFF
--- a/crates/applesauce/src/threads/writer.rs
+++ b/crates/applesauce/src/threads/writer.rs
@@ -70,6 +70,7 @@ impl Handler {
         };
         let max_compressed_size =
             (context.orig_metadata.len() as f64 * minimum_compression_ratio) as u64;
+        let mut first_block = true;
 
         chunks.try_for_each(|chunk| {
             total_compressed_size += u64::try_from(chunk.block.len()).unwrap();
@@ -82,6 +83,18 @@ impl Handler {
             }
 
             let Chunk { block, orig_size } = chunk;
+
+            if first_block {
+                first_block = false;
+                if (block.len() as f64) >= minimum_compression_ratio * (orig_size as f64) {
+                    context.progress.not_compressible_enough(&context.path);
+                    return Err(io::Error::other(format!(
+                        "already compressed ({}%)",
+                        (block.len() as f64 / orig_size as f64) * 100.0
+                    )));
+                }
+            }
+
             let _enter = block_span.enter();
 
             writer.add_block(&block)?;


### PR DESCRIPTION
Files that are already compressed (zip, parquet, gz, encrypted blobs, etc.) don't shrink. The current cumulative ratio check only trips near the end of the file, so we end up compressing ~95% of something that will never get smaller before bailing out.

This aborts after the first block when it alone fails to beat the configured minimum compression ratio (`-r`). It's content-based, so it catches incompressible inputs regardless of extension — no skip-list to maintain.

On a 500 MB incompressible file this drops the abort time from "compress most of the file, then give up" down to a single block (~64 KB). Normal compressible files are unaffected.

I went with a content check rather than an extension deny-list because extension matching misses files without recognizable extensions (encrypted blobs, already-LZ4'd data, etc.) and needs ongoing maintenance. Happy to reconsider if you'd prefer an extension list instead, or in addition.
