### PR TITLE
Show total compression in Savings stat

### DIFF
--- a/crates/applesauce-cli/src/main.rs
+++ b/crates/applesauce-cli/src/main.rs
@@ -408,7 +408,7 @@ pub fn display_stats(stats: &Stats, compress_mode: bool) {
     );
     println!(
         "Savings:                        {:.1}%",
-        stats.compression_change_portion() * 100.0
+        stats.compression_savings() * 100.0
     );
 }
 


### PR DESCRIPTION
The "Savings" stat in compress output was computed as the change in on-disk size during this run. Re-running compress on data that is already HFS-compressed always reported 0.0%, even when those files sit at a small fraction of their logical (uncompressed) size — which read like the tool did nothing, when in fact the data is heavily compressed.

Compute Savings against the uncompressed filesize instead, so the number reflects the actual on-disk state relative to the original data. A fresh compress is unaffected (start on-disk == uncompressed size); only re-runs on already-compressed data change.

Example, re-running on an already-compressed tree:

  Before:  Savings: 0.0%
  After:   Savings: 88.6%
